### PR TITLE
Added aliases for Punjabi Shahmukhi synonyms in use

### DIFF
--- a/aliases.csv
+++ b/aliases.csv
@@ -119,8 +119,8 @@ fr_fr_x_formal,fr@formal
 fr_fr_x_informal,fr@informal
 #,Punjabi Shahmukhi (Perso-Arabic script) codes in use
 lah,pa_PK
-pa_Arab,pa_PK
-pa_Arab_PK,pa_PK
+pa_arab,pa_PK
+pa_arab_pk,pa_PK
 pnb,pa_PK
 #,Country codes used instead of language,
 #,we can map only those which do not collide with existing language code

--- a/aliases.csv
+++ b/aliases.csv
@@ -117,6 +117,11 @@ fr_fo,fr@formal
 fr_form,fr@formal
 fr_fr_x_formal,fr@formal
 fr_fr_x_informal,fr@informal
+#,Punjabi Shahmukhi (Perso-Arabic script) codes in use
+lah,pa_PK
+pa_Arab,pa_PK
+pa_Arab_PK,pa_PK
+pnb,pa_PK
 #,Country codes used instead of language,
 #,we can map only those which do not collide with existing language code
 dk,da


### PR DESCRIPTION
There are various codes in use for Punjabi Shahmukhi (Perso-Arabic script used in Pakistan) across platforms for lack of a standard/conventional one, this pull requests adds them to `aliases.csv` as aliases for `pa_PK`, the code currently used on Weblate and by Android.
