### PR TITLE
Various plural rule updates; removal of Dogri duplicate

### DIFF
--- a/languages.csv
+++ b/languages.csv
@@ -63,7 +63,7 @@ bik,Bikol,2,n != 1
 bin,Bini,2,n != 1
 bla,Siksika,2,n != 1
 bm,Bambara,1,0
-bn,Bengali,2,n > 1
+bn,Bengali,2,n != 1
 bn_BD,Bengali (Bangladesh),2,n != 1
 bn_IN,Bengali (India),2,n != 1
 bnt,Bantu (Other),2,n != 1
@@ -128,7 +128,6 @@ de_CH,German (Switzerland),2,n != 1
 de_LU,German (Luxembourg),2,n != 1
 del,Delaware,2,n != 1
 den,Slave (Athapascan),2,n != 1
-dgo,Dogri,2,n > 1
 dgr,Dogrib,2,n != 1
 din,Dinka,2,n != 1
 doi,Dogri,2,n != 1
@@ -243,8 +242,8 @@ hai,Haida,2,n != 1
 haw,Hawaiian,2,n != 1
 he,Hebrew,4,(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && n % 10 == 0) ? 2 : 3))
 he_IL,Hebrew (Israel),4,(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && n % 10 == 0) ? 2 : 3))
-hi,Hindi,2,n > 1
-hi_Latn,Hindi (latin),2,n > 1
+hi,Hindi,2,n != 1
+hi_Latn,Hindi (latin),2,n != 1
 hil,Hiligaynon,2,n != 1
 hit,Hittite,2,n != 1
 hmn,Hmong,2,n != 1
@@ -428,8 +427,8 @@ os,Ossetian,2,n != 1
 osa,Osage,1,0
 ota,Turkish (Ottoman),2,n != 1
 otk,Kokturk,2,n != 1
-pa,Punjabi,2,n > 1
-pa_PK,Punjabi (Pakistan),2,n > 1
+pa,Punjabi,2,n != 1
+pa_PK,Punjabi (Pakistan),2,n != 1
 pag,Pangasinan,2,n != 1
 pal,Pahlavi,2,n != 1
 pam,Pampanga,2,n != 1
@@ -582,7 +581,7 @@ uz_Latn,Uzbek (latin),2,n != 1
 vai,Vai,2,n != 1
 ve,Venda,2,n != 1
 vec,Venetian,2,n != 1
-vi,Vietnamese,1,0
+vi,Vietnamese,2,n != 1
 vls,Flemish (West),2,n != 1
 vo,Volapük,2,n != 1
 vot,Votic,2,n != 1


### PR DESCRIPTION
## Proposed changes

This includes some minor updates to `language.csv` for consistency:

* Set `n !=1` for closely related Indic languages which had inconsistent use of either this or `n > 1`. For example, the parent Bengali entry had `n > 1` while `n !=1` was used for the country specific locales. Likewise, Hindi and Urdu are registers of the same language (Hindustani) but had different rules, and Dogri and Punjabi which are very closely related had different rules. The reason for preferring `n != 1` is that in these languages, even though it is more natural to use "none of" than the number zero, the plural "other" form is a safer option for something that sounds right in this context. There is some flexibility in the meaning of plural because of politeness rules in these languages - if you were talking about a relative's or friend's house for example, you would say the equivalent of "their houses," because the plural forms are considered more polite.

* Dogri had two entries, `doi` and `dgo`. `doi` is the one used by Android, and I think `dgo` is technically supposed to be for a "standard" dialect of Dogri, but I am unaware of any software which makes this distinction; generally they are treated as aliases.

* Vietnamese has been changed to use one / other `n !=0` plurals. There is a good explanation of why this is necessary here, on a ticket for fixing this with CLDR https://cldr.unicode.org/index/cldr-spec/plural-rules

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ X] I have described the changes in the commit messages.

