### PR TITLE
Dogri alias added for doi / dgo

### DIFF
--- a/aliases.csv
+++ b/aliases.csv
@@ -122,6 +122,8 @@ lah,pa_PK
 pa_arab,pa_PK
 pa_arab_pk,pa_PK
 pnb,pa_PK
+#,Dogri equivalent macrolanguage/language codes
+dgo,doi
 #,Country codes used instead of language,
 #,we can map only those which do not collide with existing language code
 dk,da


### PR DESCRIPTION
## Proposed changes

Dogri has the codes `doi` and `dgo` which may be treated as equivalent. I aliased `dgo` to `doi` since `doi` is the one I have seen in use in Android which supports this locale.
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ X] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
