### PR TITLE
fix: remove duplicate plural definitions for Qt

### DIFF
--- a/qt.csv
+++ b/qt.csv
@@ -31,7 +31,6 @@ et,Estonian,2,(n != 1)
 eu,Basque,2,(n != 1)
 fa,Persian,1,0
 fi,Finnish,2,(n != 1)
-fil,Filipino,2,(n > 1)
 fil,Filipino,3,(n==1 ? 0 : (n%10==4 || n%10==6 || n%10== 9) ? 1 : 2)
 fj,Fijian,1,0
 fo,Faroese,2,(n != 1)
@@ -50,7 +49,6 @@ hi,Hindi,2,(n != 1)
 hr,Croatian,3,(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)
 hu,Hungarian,1,0
 hy,Armenian,2,(n > 1)
-ia,Interlingua,2,(n != 1)
 ia,Interlingua,2,(n != 1)
 id,Indonesian,1,0
 ik,Inupiaq,3,(n==1 ? 0 : n==2 ? 1 : 2)

--- a/scripts/export-qt
+++ b/scripts/export-qt
@@ -11,7 +11,7 @@ import csv
 ALIASES = {
     "Chinese": ("Chinese (Simplified Han script)", "Chinese (Traditional Han script)"),
     "WesternFrisian": ("Frisian",),
-    "Interlingue": ("Interlingua",),
+    "Interlingue": (),  # Ignore, duplicate for Interlingua
     "Khmer": ("Khmer (Central)",),
     "Kirghiz": ("Kyrgyz",),
     "NorthernSotho": ("Pedi",),
@@ -56,6 +56,9 @@ PLURALS = {}
 def handle_language(parts):
     text = "".join(parts).replace("\n", "")[31:]
     name = text.split("[", 1)[0]
+    # Remove duplicate definition
+    if name == "frenchStyleLanguages":
+        text = text.replace("QLocale::Filipino,", "")
     # Hack to deal with frenchStyleCountries
     if name == "frenchStyleLanguages":
         text = text.replace("Portuguese", "PortugueseBrasil")
@@ -103,11 +106,14 @@ with open("modules/qttools/src/linguist/shared/numerus.cpp") as handle:
             in_table = True
 
 output = []
+processed = set()
 
 
 def generate(group, name):
     definition = DEFINITIONS[name]
     plural = PLURALS[group]
+    if definition[0] in processed:
+        raise ValueError(f"Duplicate definition for {definition[0]}")
     output.append(
         (
             definition[0],
@@ -116,6 +122,7 @@ def generate(group, name):
             plural[1],
         )
     )
+    processed.add(definition[0])
 
 
 for group, languages in LANGUAGES.items():

--- a/scripts/lint
+++ b/scripts/lint
@@ -24,6 +24,7 @@ def parse_csv(name):
 languages = parse_csv("languages.csv")
 aliases = parse_csv("aliases.csv")
 cldr = parse_csv("cldr.csv")
+parse_csv("qt.csv")
 default_countries = parse_csv("default_countries.csv")
 
 for alias in aliases:

--- a/weblate_language_data/plurals.py
+++ b/weblate_language_data/plurals.py
@@ -622,15 +622,6 @@ QTPLURALS = (
         # variant of the language. It could contain a region, age (Old, Middle, ...)
         # or other variant.
         _("Filipino"),
-        2,
-        "(n > 1)",
-    ),
-    (
-        "fil",
-        # Translators: Language name for ISO code "fil". The parenthesis clarifies
-        # variant of the language. It could contain a region, age (Old, Middle, ...)
-        # or other variant.
-        _("Filipino"),
         3,
         "(n==1 ? 0 : (n%10==4 || n%10==6 || n%10== 9) ? 1 : 2)",
     ),
@@ -786,15 +777,6 @@ QTPLURALS = (
         _("Armenian"),
         2,
         "(n > 1)",
-    ),
-    (
-        "ia",
-        # Translators: Language name for ISO code "ia". The parenthesis clarifies
-        # variant of the language. It could contain a region, age (Old, Middle, ...)
-        # or other variant.
-        _("Interlingua"),
-        2,
-        "(n != 1)",
     ),
     (
         "ia",


### PR DESCRIPTION
## Proposed changes

The source file contains ambiguous definition for Filipino and double definition for Interlingua.

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
