### PR TITLE
Adds Hungarian (`hu`) to `DOCUMENTATION_LANGUAGES` in `docs.py`.

### DIFF
--- a/weblate_language_data/docs.py
+++ b/weblate_language_data/docs.py
@@ -22,4 +22,5 @@ DOCUMENTATION_LANGUAGES = {
     "de": "de",
     "nl": "nl",
     "ga": "ga",
+    "hu": "hu",
 }


### PR DESCRIPTION
The Hungarian documentation was previously only partially translated, which might be the reason it was not included.

Now that the `docs.po` file is 100% translated, it would make sense to include `"hu": "hu"` in `DOCUMENTATION_LANGUAGES` so the Hungarian docs can be built and published as well.