### PR TITLE
Fix for Duplication in regular expression character class

### DIFF
--- a/scripts/generate-language-data.py
+++ b/scripts/generate-language-data.py
@@ -17,7 +17,7 @@ from itertools import chain
 
 SPLIT_RE = re.compile(
     r"(?:\&(?:nbsp|rsaquo|lt|gt|amp|ldquo|rdquo|times|quot);|"
-    r'[() ,.^`"\'\\/_<>!?;:|{}*^@%#&~=+\r\n✓—-…\[\]0-9-])+',
+    r'[() ,.^`"\'\\/_<>!?;:|{}*@%#&~=+\r\n✓—-…\[\]0-9-])+',
 )
 
 HEADER = '''# Copyright © Michal Čihař <michal@weblate.org>


### PR DESCRIPTION
To fix the problem, we should simplify the character class by ensuring each character appears only once. In this script, `SPLIT_RE` is defined at lines 18–21; inside the second raw string (line 20) the character class includes `^` twice: once near the start and once later before `@`. In Python regex syntax, a duplicated `^` in the middle of a character class is just redundant; removing one occurrence will not affect the matching behavior at all.

The best minimal fix is therefore to delete one of the `^` characters inside the character class. Specifically, on line 20 we will change:

```py
r'[() ,.^`"\'\\/_<>!?;:|{}*^@%#&~=+\r\n✓—-…\[\]0-9-])+
```

to:

```py
r'[() ,.^`"\'\\/_<>!?;:|{}*@%#&~=+\r\n✓—-…\[\]0-9-])+
```

i.e., remove the second `^` that appears just before `@`. No imports or additional code are needed, and functionality remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._